### PR TITLE
Multiple

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/upload",
-  "version": "1.1.0",
+  "version": "0.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/upload",
-      "version": "1.1.0",
+      "version": "0.1.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "utif": "^3.1.0",

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -1,27 +1,37 @@
 import { v4 as guidGenerator } from "uuid";
 
+interface FileInfo {
+  fileName: string;
+  fileID?: string;
+  resolution_x?: number;
+  resolution_y?: number;
+  resolution_z?: number;
+  width: number;
+  height: number;
+}
+
 export class ImageFileInfo {
-  private fileName: string; // Name of imported image file
+  readonly fileName: string;
 
-  private fileID: string; // ID of image file
+  readonly fileID: string;
 
-  public resolution_x: number;
+  readonly resolution_x: number;
 
-  public resolution_y: number;
+  readonly resolution_y: number;
 
-  public resolution_z: number;
+  readonly resolution_z: number;
 
-  public width: number; // grid width boxes
+  readonly width: number;
+  
+  readonly height: number;
 
-  public height: number; // grid height boxes
-
-  constructor(fileName: string, fileID?: string) {
-    this.fileName = fileName;
-    this.fileID = fileID || guidGenerator();
-    this.resolution_x = 0;
-    this.resolution_y = 0;
-    this.resolution_z = 0;
-    this.width = 0;
-    this.height = 0;
+  constructor(fileInfo: FileInfo) {
+    this.fileName = fileInfo.fileName;
+    this.fileID = fileInfo.fileID || guidGenerator();
+    this.resolution_x = fileInfo.resolution_x;
+    this.resolution_y = fileInfo.resolution_y;
+    this.resolution_z = fileInfo.resolution_z;
+    this.width = fileInfo.width;
+    this.height = fileInfo.height;
   }
 }

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -22,7 +22,7 @@ export class ImageFileInfo {
   readonly resolution_z: number;
 
   readonly width: number;
-  
+
   readonly height: number;
 
   constructor(fileInfo: FileInfo) {

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -8,6 +8,7 @@ interface FileInfo {
   resolution_z?: number;
   width: number;
   height: number;
+  num_slices: number;
 }
 
 export class ImageFileInfo {
@@ -25,6 +26,8 @@ export class ImageFileInfo {
 
   readonly height: number;
 
+  readonly num_slices: number;
+
   constructor(fileInfo: FileInfo) {
     this.fileName = fileInfo.fileName;
     this.fileID = fileInfo.fileID || guidGenerator();
@@ -33,5 +36,6 @@ export class ImageFileInfo {
     this.resolution_z = fileInfo.resolution_z;
     this.width = fileInfo.width;
     this.height = fileInfo.height;
+    this.num_slices = fileInfo.num_slices;
   }
 }

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -9,6 +9,7 @@ interface FileInfo {
   width: number;
   height: number;
   num_slices: number;
+  num_channels: number;
 }
 
 export class ImageFileInfo {
@@ -28,6 +29,8 @@ export class ImageFileInfo {
 
   readonly num_slices: number;
 
+  readonly num_channels: number;
+
   constructor(fileInfo: FileInfo) {
     this.fileName = fileInfo.fileName;
     this.fileID = fileInfo.fileID || guidGenerator();
@@ -37,5 +40,6 @@ export class ImageFileInfo {
     this.width = fileInfo.width;
     this.height = fileInfo.height;
     this.num_slices = fileInfo.num_slices;
+    this.num_channels = fileInfo.num_channels;
   }
 }

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -102,7 +102,10 @@ export class UploadImage extends Component<Props> {
           // If the resolution unit is 1, assume that everything has been scaled
           // according to the Z resolution (i.e resolutionZ = 1)
           // else assume that the Z resolution is the same as the X resolution.
-          if (resolutionUnit !== 1) {
+          if (resolutionUnit === 1) {
+            resolutionZ = 1;
+          }
+          else {
             resolutionZ = resolutionX;
           }
         }

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -170,6 +170,7 @@ export class UploadImage extends Component<Props> {
                 resolution_z: resolutionZ,
                 width,
                 height,
+                num_slices: slicesData.length
               }),
               slicesData
             );

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -59,7 +59,7 @@ export class UploadImage extends Component<Props> {
                 width: image.width,
                 height: image.height,
                 num_slices: 1,
-                num_channels: 3
+                num_channels: 3,
               }),
               slicesData
             );
@@ -104,8 +104,7 @@ export class UploadImage extends Component<Props> {
           // else assume that the Z resolution is the same as the X resolution.
           if (resolutionUnit === 1) {
             resolutionZ = 1;
-          }
-          else {
+          } else {
             resolutionZ = resolutionX;
           }
         }

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -145,6 +145,7 @@ export class UploadImage extends Component<Props> {
             slicesDataPromises.push(new Array<Promise<ImageBitmap>>());
           }
 
+          // prettier-ignore
           slicesDataPromises[Math.floor(i / channels)][channel] = createImageBitmap(
             canvas
           );
@@ -155,6 +156,7 @@ export class UploadImage extends Component<Props> {
         // (this should make it faster, not slower)
         // see https://eslint.org/docs/rules/no-await-in-loop
         // also https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all
+        // prettier-ignore
         const halfUnwrapped: Promise<ImageBitmap[]>[] = slicesDataPromises.map(
           async (sliceChannels) => Promise.all(sliceChannels)
         );

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -58,6 +58,8 @@ export class UploadImage extends Component<Props> {
                 fileName: imageFile.name,
                 width: image.width,
                 height: image.height,
+                num_slices: 1,
+                num_channels: 3
               }),
               slicesData
             );
@@ -170,7 +172,8 @@ export class UploadImage extends Component<Props> {
                 resolution_z: resolutionZ,
                 width,
                 height,
-                num_slices: slicesData.length
+                num_slices: slicesData.length,
+                num_channels: slicesData[0].length,
               }),
               slicesData
             );


### PR DESCRIPTION
# Description

Adds a boolean prop called `multiple` to the `UploadImage` class, which if true will produce a file dialog allowing multiple files to be selected. `UploadImage` will then iterate through the chosen images and do its usual thing for each of them in turn.

Also makes all the `ImageFileInfo` fields `readonly`, as discussed on the morning of 12/05/2021. This required me to refactor `UploadImage` a bit, which accounts for most of the lines changed in that file.

relates https://github.com/gliff-ai/curate/pull/37

# Dependency changes

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
