### PR TITLE
feat: add md5 to ImageFileInfo on upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.4",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "ts-md5": "^1.2.9",
         "utif": "^3.1.0",
         "uuid": "^8.3.2"
       },
@@ -13790,6 +13791,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/ts-md5": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
+      "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.10.1",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.10.1.tgz",
@@ -25815,6 +25821,11 @@
           }
         }
       }
+    },
+    "ts-md5": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.2.9.tgz",
+      "integrity": "sha512-/Efr7ZfGf8P+d9HXh0PLQD1CDipqD8j9apCFG96pODDoEaFLxXpV4En6tAc6y3fWyfhFGrqtNBRBS+eLVIB2uQ=="
     },
     "tsconfig-paths": {
       "version": "3.10.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/upload",
-  "version": "0.1.4",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/upload",
-      "version": "0.1.4",
+      "version": "0.2.1",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ts-md5": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "webpack-dev-server": "^3.11.2"
   },
   "dependencies": {
+    "ts-md5": "^1.2.9",
     "utif": "^3.1.0",
     "uuid": "^8.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gliff-ai/upload",
-  "version": "0.1.4",
+  "version": "0.2.1",
   "description": "gliff.ai UPLOAD - a React component for uploading multidimensional images",
   "main": "dist/main.js",
   "module": "src/index.tsx",

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -11,6 +11,7 @@ interface FileInfo {
   size: number; // in bytes
   num_slices: number;
   num_channels: number;
+  content_hash?: string; // i.e. md5
 }
 
 export class ImageFileInfo {
@@ -34,6 +35,8 @@ export class ImageFileInfo {
 
   readonly num_channels: number;
 
+  readonly content_hash: string; // i.e. md5
+
   constructor(fileInfo: FileInfo) {
     this.fileName = fileInfo.fileName;
     this.fileID = fileInfo.fileID || guidGenerator();
@@ -45,5 +48,6 @@ export class ImageFileInfo {
     this.height = fileInfo.height;
     this.num_slices = fileInfo.num_slices;
     this.num_channels = fileInfo.num_channels;
+    this.content_hash = fileInfo.content_hash;
   }
 }

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -1,4 +1,5 @@
 import React, { Component, ReactNode } from "react";
+import { Md5 } from "ts-md5";
 import * as UTIF from "utif";
 import { ImageFileInfo } from "./ImageFileInfo";
 
@@ -48,6 +49,7 @@ export class UploadImage extends Component<Props> {
     reader.onload = () => {
       const image = new Image();
       image.src = reader.result.toString();
+      const md5 = Md5.hashStr(reader.result.toString());
 
       image.onload = () => {
         createImageBitmap(image)
@@ -61,6 +63,7 @@ export class UploadImage extends Component<Props> {
                 height: image.height,
                 num_slices: 1,
                 num_channels: 3,
+                content_hash: md5,
               }),
               slicesData
             );


### PR DESCRIPTION
## Description

Added MD5 to ImageFileInfo, calculated using the ts-md5 package.

## Dependency changes

Added: https://www.npmjs.com/package/ts-md5
Has the pipfile.lock or package-lock.json been updated? Yes

## Testing

None

## Documentation

None

## Migrations (if applicable)

N/A

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New migrations have been committed
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
