### PR TITLE
chore!: bump to v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gliff-ai/upload",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@gliff-ai/upload",
-      "version": "0.2.2",
+      "version": "1.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "ts-md5": "^1.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gliff-ai/upload",
-  "version": "0.2.2",
+  "version": "1.0.0",
   "description": "gliff.ai UPLOAD - a React component for uploading multidimensional images",
   "main": "dist/index.es.js",
   "module": "dist/index.es.js",


### PR DESCRIPTION
as it says on the tin - should force a breaking change bumping us to v1.0.0; this makes dep management in DOMINATE easier