### PR TITLE
refactor!: Delete ImageFileInfo class

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 ![Repo License](https://img.shields.io/github/license/gliff-ai/upload?color=0078FF&style=flat-square) ![Repository Size](https://img.shields.io/github/repo-size/gliff-ai/upload?style=flat-square&color=f2f2f2) ![Latest Tag](https://img.shields.io/github/v/tag/gliff-ai/upload?&label=latest%20tag&style=flat-square&color=f2f2f2) ![Number of Open Issues](https://img.shields.io/github/issues/gliff-ai/upload?style=flat-square&color=yellow) ![Number of Open Pull Requests](https://img.shields.io/github/issues-pr/gliff-ai/upload?style=flat-square&color=yellow) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/contributors-4-yellow.svg?style=flat-square)](#contributors)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 👋 **Welcome in!** 👋
 
-This repository contains the Open Source code for [gliff.ai](https://gliff.ai)’s UPLOAD support library (gliff.ai’s component for uploading multidimensional images). 
+This repository contains the Open Source code for [gliff.ai](https://gliff.ai)’s UPLOAD support library (gliff.ai’s component for uploading multidimensional images).
 
-UPLOAD aims to allow users to easily upload a variety of image files, including multidimensional TIFFs, for the purposes of developing imaging AI products. When the full [gliff.ai platform](https://gliff.ai/software/) is used, UPLOAD provides just one step in developing high-quality and auditable datasets that satisfy any relevant regulatory frameworks which enables our users to build world-changing and trustworthy AI models and products. 
+UPLOAD aims to allow users to easily upload a variety of image files, including multidimensional TIFFs, for the purposes of developing imaging AI products. When the full [gliff.ai platform](https://gliff.ai/software/) is used, UPLOAD provides just one step in developing high-quality and auditable datasets that satisfy any relevant regulatory frameworks which enables our users to build world-changing and trustworthy AI models and products.
 
 ✅ **We welcome contributions on this repository!** ✅
 
@@ -75,7 +76,7 @@ Import the `UploadImage` module and the `ImageFileInfo` type:
 
 ```javascript
 import { UploadImage } from @gliff-ai/upload;
-import { ImageFileInfo } from @gliff-ai/upload/typings;
+import type { ImageFileInfo } from @gliff-ai/upload;
 ```
 
 Use the `UploadImage` module:
@@ -108,12 +109,13 @@ The example above uses [Material-UI](https://material-ui.com/).
 
 [{{back to navigation}}](#table-of-contents)
 
-We welcome all contributors and any contributions on this project through the likes of feedback on or suggesting features and enhancements, raising bug problems, reporting on security vulnerabilities, reviewing code, requesting or creating tests, user testing etc. to ensure gliff.ai can help enable the best and biggest positive impact possible. 
+We welcome all contributors and any contributions on this project through the likes of feedback on or suggesting features and enhancements, raising bug problems, reporting on security vulnerabilities, reviewing code, requesting or creating tests, user testing etc. to ensure gliff.ai can help enable the best and biggest positive impact possible.
 
 Sounds good and want to contribute to the project? 🧑‍💻 \
-Please check the [gliff.ai Contribution Guide]((https://github.com/gliff-ai/.github/blob/main/CONTRIBUTING.md)) 👋 before you get started. Don’t forget the [gliff.ai Code of Conduct]((https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md)) ⚠️ and  [gliff.ai Security Policy]((https://github.com/gliff-ai/.github/blob/main/SECURITY.md)) 🔒 too!
+Please check the [gliff.ai Contribution Guide](<(https://github.com/gliff-ai/.github/blob/main/CONTRIBUTING.md)>) 👋 before you get started. Don’t forget the [gliff.ai Code of Conduct](<(https://github.com/gliff-ai/.github/blob/main/CODE_OF_CONDUCT.md)>) ⚠️ and [gliff.ai Security Policy](<(https://github.com/gliff-ai/.github/blob/main/SECURITY.md)>) 🔒 too!
 
 A big thank you from the entire gliff.ai team to these fellow contributors ([emoji key](https://allcontributors.org/docs/en/emoji-key)):
+
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore-start -->
 <!-- markdownlint-disable -->

--- a/src/ImageFileInfo.tsx
+++ b/src/ImageFileInfo.tsx
@@ -1,53 +1,12 @@
-import { v4 as guidGenerator } from "uuid";
-
-interface FileInfo {
+export interface ImageFileInfo {
   fileName: string;
-  fileID?: string;
-  resolution_x?: number;
-  resolution_y?: number;
-  resolution_z?: number;
   width: number;
   height: number;
   size: number; // in bytes
   num_slices: number;
   num_channels: number;
   content_hash?: string; // i.e. md5
-}
-
-export class ImageFileInfo {
-  readonly fileName: string;
-
-  readonly fileID: string;
-
-  readonly resolution_x: number;
-
-  readonly resolution_y: number;
-
-  readonly resolution_z: number;
-
-  readonly width: number;
-
-  readonly height: number;
-
-  readonly size: number; // in bytes
-
-  readonly num_slices: number;
-
-  readonly num_channels: number;
-
-  readonly content_hash: string; // i.e. md5
-
-  constructor(fileInfo: FileInfo) {
-    this.fileName = fileInfo.fileName;
-    this.fileID = fileInfo.fileID || guidGenerator();
-    this.resolution_x = fileInfo.resolution_x;
-    this.resolution_y = fileInfo.resolution_y;
-    this.resolution_z = fileInfo.resolution_z;
-    this.size = fileInfo.size;
-    this.width = fileInfo.width;
-    this.height = fileInfo.height;
-    this.num_slices = fileInfo.num_slices;
-    this.num_channels = fileInfo.num_channels;
-    this.content_hash = fileInfo.content_hash;
-  }
+  resolution_x?: number;
+  resolution_y?: number;
+  resolution_z?: number;
 }

--- a/src/UploadImage.tsx
+++ b/src/UploadImage.tsx
@@ -166,7 +166,7 @@ export class UploadImage extends Component<Props> {
             const slicesData = imageBitmaps.map((imageBitmap) => [imageBitmap]);
             return {
               slicesData,
-              imageFileInfo: new ImageFileInfo({
+              imageFileInfo: {
                 fileName: imageFile.name,
                 size: imageFile.size,
                 width: image.width,
@@ -174,7 +174,7 @@ export class UploadImage extends Component<Props> {
                 num_slices: 1,
                 num_channels: 3,
                 content_hash: "test",
-              }),
+              },
             } as CallbackArgs;
           });
         }
@@ -210,7 +210,7 @@ export class UploadImage extends Component<Props> {
             .then((RGBImageBitmaps) => {
               resolve({
                 slicesData: [RGBImageBitmaps],
-                imageFileInfo: new ImageFileInfo({
+                imageFileInfo: {
                   fileName: imageFile.name,
                   size: imageFile.size,
                   width: image.width,
@@ -218,7 +218,7 @@ export class UploadImage extends Component<Props> {
                   num_slices: 1,
                   num_channels: 3,
                   content_hash: md5,
-                }),
+                },
               });
             })
             .catch((e) => log.error(e));
@@ -328,7 +328,7 @@ export class UploadImage extends Component<Props> {
           .then((slicesData) => {
             resolve({
               slicesData,
-              imageFileInfo: new ImageFileInfo({
+              imageFileInfo: {
                 fileName: imageFile.name,
                 resolution_x: resolutionX,
                 resolution_y: resolutionY,
@@ -338,7 +338,7 @@ export class UploadImage extends Component<Props> {
                 height,
                 num_slices: slicesData.length,
                 num_channels: slicesData[0].length,
-              }),
+              },
             });
           })
           .catch((e) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,2 @@
 export { UploadImage } from "./UploadImage";
-export { ImageFileInfo } from "./ImageFileInfo";
+export type { ImageFileInfo } from "./ImageFileInfo";


### PR DESCRIPTION
## Description
This PR is for deleting the `ImageFileInfo` class. I had a chat with @philipjackson and we agreed upon the fact that this class is not required (the only thing it does is set an ID we don't use). I still keep the interface for now as that is imported in ANNOTATE and CURATE; once the repo with all the gliff's types is ready we will be able to import it from there.

## Checklist:

Put an `x` in the boxes that apply to this pull request (you can also fill these out after opening the pull request). If you're unsure about any of these, don't hesitate to leave a comment on this pull request!

- [ ] I have read the gliff.ai Contribution Guide.
- [ ] I have requested to **pull a branch** and not from main.
- [ ] I have checked all commit message styles match the requested structure.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have performed a self-review of my own code.
- [ ] I have assigned **3 or less** reviewers.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] My changes generate no new warnings.
- [ ] I have made corresponding changes to the documentation.
- [ ] New database changes have been committed.
- [ ] If appropriate, I have bumped any version numbers.
